### PR TITLE
Code quality configuration for Codeac.io

### DIFF
--- a/.codeac.yml
+++ b/.codeac.yml
@@ -1,0 +1,8 @@
+---
+
+version: '1'
+tools:
+  eslint:
+    ext: '.js,.ts'
+  tslint:
+    enabled: false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,8 +23,7 @@
         "plugin:eslint-comments/recommended",
         "plugin:unicorn/recommended",
         "plugin:@typescript-eslint/recommended",
-        "prettier",
-        "prettier/@typescript-eslint"
+        "prettier"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,10 @@
         "project": "./tsconfig.json"
     },
     "rules": {
+        "complexity": [
+            "error",
+            10
+        ],
         "indent": [
             "error",
             4

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 [![DeepSource](https://deepsource.io/gh/AlexRogalskiy/weather-time.svg/?label=active+issues\&show_trend=true)](https://deepsource.io/gh/AlexRogalskiy/weather-time/?ref=repository-badge)
 [![DeepScan grade](https://deepscan.io/api/teams/11946/projects/16471/branches/354704/badge/grade.svg)](https://deepscan.io/dashboard#view=project\&tid=11946\&pid=16471\&bid=354704)
+[![Codeac.io](https://static.codeac.io/badges/2-344897154.svg "Codeac.io")](https://app.codeac.io/github/AlexRogalskiy/weather-time)
 [![Tokei](https://tokei.rs/b1/github/AlexRogalskiy/weather-time?category=lines)](https://github.com/XAMPPRocky/tokei)
 ![Mergify Status](https://img.shields.io/endpoint.svg?url=https://gh.mergify.io/badges/AlexRogalskiy/weather-time)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "eslint-plugin-unicorn": "^17.2.0",
         "eslint-import-resolver-typescript": "^2.0.0",
         "eslint-plugin-eslint-comments": "^3.1.2",
-        "eslint-config-prettier": "^6.15.0",
+        "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-github": "^4.1.1",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jest": "^23.20.0",


### PR DESCRIPTION
Hello Alex,
I went across your repo and saw a good amount of work you have done over here. Good job! 🥇

You recently also tried [Codeac.io](https://www.codeac.io?utm_campaign=AlexRogalskiy/weather-time) and you probably haven't had a good experience just because of lack of correct configuration.

## Changelog
- :sparkles: enhancement: I've added configuration for ESLint to support also TypeScript since [TSLint is deprecated](https://www.codeac.io/blog/the-future-of-tslint-and-what-it-means-for-codeac-io-users.html?utm_campaign=AlexRogalskiy/weather-time) by now.
- :sparkles: enhancement: ESLint [configuration for Prettier](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21) changed a little bit too so I've updated that as well. 
- enhancement: Added Codeac.io badge: [![Codeac.io](https://static.codeac.io/badges/2-344897154.svg "Codeac.io")](https://app.codeac.io/github/AlexRogalskiy/weather-time)
- :sparkles: enhancement: I've also noticed you don't have an explicitly specified rule for [Cyclomatic Complexity](https://eslint.org/docs/rules/complexity) so I've added that one.

![js-complexity](https://user-images.githubusercontent.com/53786124/121080356-9c5c6c00-c7db-11eb-886a-7a73a3aeb5c3.png)

Hope this will be helpful for you and find Codeac more useful after this. Right after you merge it, you should see much better results than before.

Let me know if you need any more help. Btw, Codeac.io can analyze also [Infrastructure as Code](https://www.codeac.io/infrastructure-as-code.html?utm_campaign=AlexRogalskiy/weather-time) if you want to have a look.

Michal Šimon
CEO @ [Codeac.io](https://www.codeac.io?utm_campaign=AlexRogalskiy/weather-time)

PS: Keep doing open-source, please! We all appreciate your work a lot! :)